### PR TITLE
Expose Epic Hiding options in popup

### DIFF
--- a/app/popup.html
+++ b/app/popup.html
@@ -19,7 +19,10 @@
       <div id="hide-epics-options">
         <label><input type="checkbox" id="toggle-cards"/> Hide epic cards</label>
         <input type="text" id="epics-list" class="hidden" placeholder="(i.e. 133, 152)"/>
+        <button id="save-epics">Save</button>
       </div>
+
+      <div id="status-message"></div>
 
     </div>
 

--- a/app/popup.html
+++ b/app/popup.html
@@ -18,8 +18,10 @@
 
       <div id="hide-epics-options">
         <label><input type="checkbox" id="toggle-cards"/> Hide epic cards</label>
-        <input type="text" id="epics-list" class="hidden" placeholder="(i.e. 133, 152)"/>
-        <button id="save-epics">Save</button>
+        <div id="epics-container" class="hidden">
+          <input type="text" id="epics-list" placeholder="(i.e. 133, 152)"/>
+          <button id="save-epics">Save</button>
+        </div>
       </div>
 
       <div id="status-message"></div>

--- a/app/popup.html
+++ b/app/popup.html
@@ -11,10 +11,12 @@
     <!-- endbuild -->
   </head>
   <body>
-    <h1>Made with love by</h1>
-    <p><a href="http://adorable.io/?utm_source=chrome-extension&utm_campaign=version-one-shot" target="_blank">adorable.io</a></p>
 
-    <label><input type="checkbox" id="toggle-cards"/> Toggle card hiding</label>
+    <h1>VersionOne-Shot</h1>
+
+    <div class="options">
+      <label><input type="checkbox" id="toggle-cards"/> Hide epic cards</label>
+    </div>
 
     <!-- build:js scripts/popup-vendor.js -->
     <!-- bower:js -->
@@ -25,5 +27,10 @@
     <!-- build:js scripts/popup.js -->
     <script src="scripts/popup.js"></script>
     <!-- endbuild -->
+
+    <footer>
+      <p>Made with love by <a href="http://adorable.io/?utm_source=chrome-extension&utm_campaign=version-one-shot" target="_blank">adorable.io</a></p>
+    </footer>
+
   </body>
 </html>

--- a/app/popup.html
+++ b/app/popup.html
@@ -19,7 +19,7 @@
       <div id="hide-epics-options">
         <label><input type="checkbox" id="toggle-cards"/> Hide epic cards</label>
         <div id="epics-container" class="hidden">
-          <input type="text" id="epics-list" placeholder="(i.e. 133, 152)"/>
+          <input type="text" id="epics-list" placeholder="(e.g. 197429, 207470)"/>
           <button id="save-epics">Save</button>
         </div>
       </div>

--- a/app/popup.html
+++ b/app/popup.html
@@ -14,8 +14,13 @@
 
     <h1>VersionOne-Shot</h1>
 
-    <div class="options">
-      <label><input type="checkbox" id="toggle-cards"/> Hide epic cards</label>
+    <div id="options">
+
+      <div id="hide-epics-options">
+        <label><input type="checkbox" id="toggle-cards"/> Hide epic cards</label>
+        <input type="text" id="epics-list" class="hidden" placeholder="(i.e. 133, 152)"/>
+      </div>
+
     </div>
 
     <!-- build:js scripts/popup-vendor.js -->

--- a/app/popup.html
+++ b/app/popup.html
@@ -14,6 +14,8 @@
     <h1>Made with love by</h1>
     <p><a href="http://adorable.io/?utm_source=chrome-extension&utm_campaign=version-one-shot" target="_blank">adorable.io</a></p>
 
+    <label><input type="checkbox" id="toggle-cards"/> Toggle card hiding</label>
+
     <!-- build:js scripts/popup-vendor.js -->
     <!-- bower:js -->
     <script src="bower_components/jquery/dist/jquery.js"></script>

--- a/app/scripts.babel/contentscript.js
+++ b/app/scripts.babel/contentscript.js
@@ -11,7 +11,9 @@ function one_shot() {
   prettify_cards();
   prettify_board();
   hide_columns();
-  remove_epics();
+  hide_epics();
+
+  chrome.storage.onChanged.addListener(handle_storage_changes);
 }
 
 function prettify_cards() {
@@ -97,7 +99,7 @@ function add_css_to_document(css) {
   document.getElementsByTagName('head')[0].appendChild(style);
 }
 
-function remove_epic(epic_token) {
+function hide_epic(epic_token) {
   let epics = document.querySelectorAll(`a[rel='${epic_token}']`)
   Array.from(epics).forEach(function(e) {
     var node = e.parentNode.parentNode;
@@ -106,7 +108,7 @@ function remove_epic(epic_token) {
   });
 }
 
-function remove_epics() {
+function hide_epics() {
   chrome.storage.sync.get('epicsToHide', function(items) {
     let epic_collection = items.epicsToHide.split(',');
 
@@ -114,9 +116,32 @@ function remove_epics() {
 
     epic_collection.forEach(function(number) {
       number = number.trim();
-      remove_epic(`Epic:${number}`);
+      hide_epic(`Epic:${number}`);
     });
   });
+}
+
+function show_epics() {
+  var node;
+  while (node = window.v1hiddenEpics.pop()) {
+    node.style.display = '';
+  }
+}
+
+function toggle_epics(hide) {
+  if (hide) {
+    hide_epics();
+  } else {
+    show_epics();
+  }
+}
+
+function handle_storage_changes(changes) {
+  for (var key in changes) {
+    if (key === 'hideEpicCards') {
+      toggle_epics(changes[key].newValue);
+    }
+  }
 }
 
 one_shot();

--- a/app/scripts.babel/contentscript.js
+++ b/app/scripts.babel/contentscript.js
@@ -142,7 +142,7 @@ function show_epics() {
 
 function handle_storage_changes(changes) {
   for (var key in changes) {
-    if (key === 'hideEpicCards') {
+    if (key === 'hideEpicCards' || key === 'epicsToHide') {
       toggle_epic_cards();
     }
   }

--- a/app/scripts.babel/contentscript.js
+++ b/app/scripts.babel/contentscript.js
@@ -100,13 +100,17 @@ function add_css_to_document(css) {
 function remove_epic(epic_token) {
   let epics = document.querySelectorAll(`a[rel='${epic_token}']`)
   Array.from(epics).forEach(function(e) {
-    e.parentNode.parentNode.remove();
+    var node = e.parentNode.parentNode;
+    window.v1hiddenEpics.push(node);
+    node.style.display = 'none';
   });
 }
 
 function remove_epics() {
   chrome.storage.sync.get('epicsToHide', function(items) {
     let epic_collection = items.epicsToHide.split(',');
+
+    window.v1hiddenEpics = [];
 
     epic_collection.forEach(function(number) {
       number = number.trim();

--- a/app/scripts.babel/contentscript.js
+++ b/app/scripts.babel/contentscript.js
@@ -11,7 +11,7 @@ function one_shot() {
   prettify_cards();
   prettify_board();
   hide_columns();
-  hide_epics();
+  toggle_epic_cards();
 
   chrome.storage.onChanged.addListener(handle_storage_changes);
 }
@@ -136,10 +136,20 @@ function toggle_epics(hide) {
   }
 }
 
+function toggle_epic_cards() {
+  chrome.storage.sync.get({ hideEpicCards: true }, function(items) {
+    if (items.hideEpicCards) {
+      hide_epics();
+    } else {
+      show_epics();
+    }
+  });
+}
+
 function handle_storage_changes(changes) {
   for (var key in changes) {
     if (key === 'hideEpicCards') {
-      toggle_epics(changes[key].newValue);
+      toggle_epic_cards();
     }
   }
 }

--- a/app/scripts.babel/contentscript.js
+++ b/app/scripts.babel/contentscript.js
@@ -99,12 +99,13 @@ function add_css_to_document(css) {
   document.getElementsByTagName('head')[0].appendChild(style);
 }
 
-function hide_epic(epic_token) {
-  let epics = document.querySelectorAll(`a[rel='${epic_token}']`)
-  Array.from(epics).forEach(function(e) {
-    var node = e.parentNode.parentNode;
-    window.v1hiddenEpics.push(node);
-    node.style.display = 'none';
+function toggle_epic_cards() {
+  chrome.storage.sync.get({ hideEpicCards: true }, function(items) {
+    if (items.hideEpicCards) {
+      hide_epics();
+    } else {
+      show_epics();
+    }
   });
 }
 
@@ -121,29 +122,22 @@ function hide_epics() {
   });
 }
 
+function hide_epic(epic_token) {
+  let epics = document.querySelectorAll(`a[rel='${epic_token}']`)
+  Array.from(epics).forEach(function(e) {
+    var node = e.parentNode.parentNode;
+    window.v1hiddenEpics.push(node);
+    node.style.display = 'none';
+  });
+}
+
 function show_epics() {
-  var node;
-  while (node = window.v1hiddenEpics.pop()) {
+  var hidden_epics = window.v1hiddenEpics || [],
+      node;
+
+  while (node = hidden_epics.pop()) {
     node.style.display = '';
   }
-}
-
-function toggle_epics(hide) {
-  if (hide) {
-    hide_epics();
-  } else {
-    show_epics();
-  }
-}
-
-function toggle_epic_cards() {
-  chrome.storage.sync.get({ hideEpicCards: true }, function(items) {
-    if (items.hideEpicCards) {
-      hide_epics();
-    } else {
-      show_epics();
-    }
-  });
 }
 
 function handle_storage_changes(changes) {

--- a/app/scripts.babel/popup.js
+++ b/app/scripts.babel/popup.js
@@ -5,7 +5,6 @@ document.addEventListener('DOMContentLoaded', function() {
   chrome.storage.sync.get({ hideEpicCards: true }, function(items) {
     hide_epics_checkbox.checked = items.hideEpicCards;
   });
-
 });
 
 document.getElementById('toggle-cards').addEventListener('change', function(e) {

--- a/app/scripts.babel/popup.js
+++ b/app/scripts.babel/popup.js
@@ -24,8 +24,8 @@ document.getElementById('toggle-cards').addEventListener('change', function(e) {
 
 function toggle_epics_list(show_it) {
   if (show_it) {
-    chrome.storage.sync.get({ columnsToHide: '' }, function(items) {
-      epics_list.value = items.columnsToHide;
+    chrome.storage.sync.get({ epicsToHide: '' }, function(items) {
+      epics_list.value = items.epicsToHide;
     });
     epics_list.classList.remove('hidden');
   } else {

--- a/app/scripts.babel/popup.js
+++ b/app/scripts.babel/popup.js
@@ -1,6 +1,12 @@
 'use strict';
 
-console.log('hi');
+document.addEventListener('DOMContentLoaded', function() {
+  var hide_epics_checkbox = document.getElementById('toggle-cards');
+  chrome.storage.sync.get({ hideEpicCards: true }, function(items) {
+    hide_epics_checkbox.checked = items.hideEpicCards;
+  });
+
+});
 
 document.getElementById('toggle-cards').addEventListener('change', function(e) {
   chrome.storage.sync.set({

--- a/app/scripts.babel/popup.js
+++ b/app/scripts.babel/popup.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var hide_epics_checkbox = document.getElementById('toggle-cards'),
-    epics_list =          document.getElementById('epics-list');
+    epics_list =          document.getElementById('epics-list'),
+    status_message =      document.getElementById('status-message');
 
 
 document.addEventListener('DOMContentLoaded', function() {
@@ -19,6 +20,19 @@ document.getElementById('toggle-cards').addEventListener('change', function(e) {
   toggle_epics_list(e.target.checked);
   chrome.storage.sync.set({
     'hideEpicCards': e.target.checked
+  });
+});
+
+document.getElementById('save-epics').addEventListener('click', function(e) {
+  e.preventDefault();
+
+  chrome.storage.sync.set({
+    epicsToHide: epics_list.value
+  }, function() {
+    status_message.textContent = 'Options saved.';
+    setTimeout(function() {
+      status_message.textContent = '';
+    }, 3000);
   });
 });
 

--- a/app/scripts.babel/popup.js
+++ b/app/scripts.babel/popup.js
@@ -1,14 +1,34 @@
 'use strict';
 
+var hide_epics_checkbox = document.getElementById('toggle-cards'),
+    epics_list =          document.getElementById('epics-list');
+
+
 document.addEventListener('DOMContentLoaded', function() {
-  var hide_epics_checkbox = document.getElementById('toggle-cards');
   chrome.storage.sync.get({ hideEpicCards: true }, function(items) {
-    hide_epics_checkbox.checked = items.hideEpicCards;
+    if (items.hideEpicCards) {
+      hide_epics_checkbox.checked = true;
+      toggle_epics_list(true);
+    } else {
+      toggle_epics_list(false);
+    }
   });
 });
 
 document.getElementById('toggle-cards').addEventListener('change', function(e) {
+  toggle_epics_list(e.target.checked);
   chrome.storage.sync.set({
     'hideEpicCards': e.target.checked
   });
 });
+
+function toggle_epics_list(show_it) {
+  if (show_it) {
+    chrome.storage.sync.get({ columnsToHide: '' }, function(items) {
+      epics_list.value = items.columnsToHide;
+    });
+    epics_list.classList.remove('hidden');
+  } else {
+    epics_list.classList.add('hidden');
+  }
+}

--- a/app/scripts.babel/popup.js
+++ b/app/scripts.babel/popup.js
@@ -1,3 +1,9 @@
 'use strict';
 
-console.log('Adorable Popup');
+console.log('hi');
+
+document.getElementById('toggle-cards').addEventListener('change', function(e) {
+  chrome.storage.sync.set({
+    'hideEpicCards': e.target.checked
+  });
+});

--- a/app/scripts.babel/popup.js
+++ b/app/scripts.babel/popup.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var hide_epics_checkbox = document.getElementById('toggle-cards'),
+    epics_container =     document.getElementById('epics-container'),
     epics_list =          document.getElementById('epics-list'),
     status_message =      document.getElementById('status-message');
 
@@ -41,8 +42,8 @@ function toggle_epics_list(show_it) {
     chrome.storage.sync.get({ epicsToHide: '' }, function(items) {
       epics_list.value = items.epicsToHide;
     });
-    epics_list.classList.remove('hidden');
+    epics_container.classList.remove('hidden');
   } else {
-    epics_list.classList.add('hidden');
+    epics_container.classList.add('hidden');
   }
 }

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -32,3 +32,7 @@ footer a, footer a:visited {
 footer a:hover, footer a:active {
   color: #f55;
 }
+
+.hidden {
+  display: none;
+}

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -41,3 +41,9 @@ footer a:hover, footer a:active {
   margin-top: 0.5em;
   margin-left: 1em;
 }
+
+#status-message {
+  margin-top: 1em;
+  font-size: 0.8em;
+  color: #f00;
+}

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -1,3 +1,34 @@
 body {
-  padding: 20px;
+  padding: 5px 20px 10px 20px;
+  width: 250px;
+  background: #efefef;
+  border: 2px solid white;
+  border-radius: 5px;
+  font-size: 14px;
+  font-weight: 300;
+}
+
+h1 {
+  color: #00A9E0;
+  line-height: 1em;
+}
+
+footer {
+  font-size: 0.8em;
+  color: #777;
+  margin-top: 1em;
+  border-top: 1px solid white;
+}
+
+footer p {
+  margin-top: 20px;
+}
+
+footer a, footer a:visited {
+  color: #f88;
+  text-decoration: none;
+}
+
+footer a:hover, footer a:active {
+  color: #f55;
 }

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -36,3 +36,8 @@ footer a:hover, footer a:active {
 .hidden {
   display: none;
 }
+
+#epics-container {
+  margin-top: 0.5em;
+  margin-left: 1em;
+}


### PR DESCRIPTION
:dollar::snake::negative_squared_cross_mark:

Fixes #5.

There's plenty of cleanup to do in this new code, but the functionality is there and this PR has been stewing for long enough, so I'm ready to merge it.
## New Features
- Controls for stuff in the popup (the thing you get when clicking the extension icon in the corner)
- Checkbox to toggle epic card hiding
- Beautiful (disclaimer: not actually beautiful) styling
- You can edit the list of epic IDs to hide right in the popup.
